### PR TITLE
Morph: set-output issue 2

### DIFF
--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Get branch name
       # see https://github.com/actions/checkout/issues/331
       id: get-branch
-      run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
+      run: echo "branch=$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')" >> $GITHUB_OUTPUT
       env:
         REPO: ${{ github.repository }}
         PR_NO: ${{ github.event.issue.number }}
@@ -79,7 +79,7 @@ jobs:
     - name: Get branch name
       # see https://github.com/actions/checkout/issues/331
       id: get-branch
-      run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
+      run: echo "branch=$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')" >> $GITHUB_OUTPUT
       env:
         REPO: ${{ github.repository }}
         PR_NO: ${{ github.event.issue.number }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,8 +45,8 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     outputs:
-      VERSION_NAME: ${{ steps.set_output.outputs.VERSION_NAME }}
-      VERSION_CODE: ${{ steps.set_output.outputs.VERSION_CODE }}
+      VERSION_NAME: ${{ env.VERSION_NAME }}
+      VERSION_CODE: ${{ env.VERSION_CODE }}
 
     steps:
       - uses: actions/checkout@v4
@@ -103,9 +103,10 @@ jobs:
           tag: "v${{ env.VERSION_NAME }}"
           overwrite: true
 
-      - name: Set output
-        id: set_output
-        run: echo "::set-output name=VERSION_NAME::${{ env.VERSION_NAME }}" && echo "::set-output name=VERSION_CODE::${{ env.VERSION_CODE }}"
+      - name: Set output variables
+        run: |
+          echo "VERSION_NAME=${{ env.VERSION_NAME }}" >> $GITHUB_ENV
+          echo "VERSION_CODE=${{ env.VERSION_CODE }}" >> $GITHUB_ENV
 
   android-release:
     concurrency: 


### PR DESCRIPTION
This PR contains the following modifications:

- AI Prompt: "set-output workflow action is deprecated and should not be used. Instead environment variables should be used. Do not introduce any new files!

Examples: ```<example_before> run: echo "::set-output name=VERSION_NAME::${{ env.VERSION_NAME }}" && echo "::set-output name=VERSION_CODE::${{ env.VERSION_CODE }}" </example_before> <example_fixed> run: echo "VERSION_CODE=${{ env.VERSION_CODE }}" >> $GITHUB_ENV && echo "VERSION_NAME=${{ env.VERSION_NAME }}" >> $GITHUB_ENV </example_fixed>```

" (Single file: Yes)

Generated by Morph.